### PR TITLE
Add MIT LICENSE and Thanks section to README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 HansO
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -149,3 +149,22 @@ FIB parser   Viterbi FEC  (fec crate)
 | 13F | 239.200 MHz |
 
 Full table: run `dab-rtl scan --channel <name>` for any channel 5A–13F.
+
+## Thanks
+
+This project stands on the shoulders of the broader open-source SDR community.
+
+- **[welle.io](https://github.com/AlbrechtL/welle.io)** — An open-source DAB/DAB+ receiver that served as the primary inspiration for the signal pipeline and protocol implementation in this project.
+- **[librtlsdr](https://github.com/osmocom/rtl-sdr)** — The foundational C library that enables software-defined radio with low-cost RTL-SDR hardware.
+- **[rtlsdr_mt](https://crates.io/crates/rtlsdr_mt)** — The Rust bindings to librtlsdr used for hardware access.
+- **[Symphonia](https://github.com/pdeljanov/Symphonia)** — A pure-Rust audio decoding library used for MP2 playback.
+- **[rustfft](https://github.com/ejmahler/RustFFT)** — High-performance FFT used in OFDM demodulation.
+- **[ratatui](https://github.com/ratatui/ratatui)** — The terminal UI framework powering the interactive station browser.
+- The **ETSI EN 300 401** standard authors for publicly documenting the DAB specification.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
+> **Note:** At runtime, this application links against `librtlsdr`, which is licensed under GPL-2.0+.
+> If you distribute a compiled binary, you may need to comply with the GPL for the combined work.


### PR DESCRIPTION
Adds a MIT LICENSE file and a Thanks/Acknowledgments section to README.md crediting welle.io, librtlsdr, and the key Rust libraries used in this project.

Closes #8

Generated with [Claude Code](https://claude.ai/code)