### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/roptaty/dab-rtl/security/code-scanning/5](https://github.com/roptaty/dab-rtl/security/code-scanning/5)

To fix this, explicitly define a minimal `permissions` block for the workflow so that `GITHUB_TOKEN` is restricted to read-only repository contents (and other scopes remain disabled) unless later tightened per job. The simplest and least intrusive fix is to add a root-level `permissions: contents: read` block, which applies to all jobs (`test` and `release`) and is sufficient for `actions/checkout`, `actions/cache`, and `actions/upload-artifact`, none of which require write access to the repo.

Concretely:
- In `.github/workflows/ci.yml`, insert a `permissions:` block near the top-level (e.g., after `name: CI` and before `on:`).  
- Set `contents: read` as the only permission, since the jobs only read source code and do not need to modify repo contents or interact with issues/PRs.  
No additional imports or methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration for enhanced security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->