### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,9 @@
 name: Security
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/roptaty/dab-rtl/security/code-scanning/7](https://github.com/roptaty/dab-rtl/security/code-scanning/7)

In general, the problem is fixed by adding an explicit `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. This can be done at the top (root) of the workflow to apply to all jobs, or per job. Here, since all jobs are security scans that only read the code and in one case upload SARIF results, we can define a global `permissions` block with `contents: read` and `security-events: write`. This both documents the workflow’s needs and ensures that it remains least-privileged regardless of repository defaults.

The single best fix without changing existing functionality is to add a root-level `permissions` block right below the workflow `name` (and above `on:`). This will apply to all jobs (`audit`, `deny`, `outdated`, `unused`, and `opengrep`). The `opengrep` job uses `github/codeql-action/upload-sarif@v3`, which requires `security-events: write`, while all other steps only need to read the repository contents, so `contents: read` and `security-events: write` are sufficient. No other changes, imports, or new methods are needed; only the YAML header of `.github/workflows/security.yml` is updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow security configuration to enhance permissions handling and improve overall CI/CD security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->