### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behaviour
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behaviour
+
+<!-- What did you expect to happen? -->
+
+## Actual Behaviour
+
+<!-- What actually happened? Include any error messages or logs. -->
+
+## Environment
+
+- OS:
+- Rust version (`rustc --version`):
+- RTL-SDR device (if applicable):
+- DAB channel / frequency:
+
+## Additional Context
+
+<!-- Any other information that might be relevant (logs, screenshots, IQ captures, etc.) -->
+
+## Related Issues
+
+<!-- Link to any related issues -->
+-

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,40 @@
+---
+name: Epic
+about: A large body of work that can be broken down into features or tasks
+title: "[Epic] "
+labels: epic
+assignees: ''
+---
+
+## Summary
+
+<!-- A brief description of the epic and its goals -->
+
+## Background / Motivation
+
+<!-- Why is this epic needed? What problem does it solve? -->
+
+## Scope
+
+### In scope
+-
+
+### Out of scope
+-
+
+## Features / Tasks
+
+<!-- List the features or tasks that make up this epic -->
+- [ ]
+- [ ]
+
+## Acceptance Criteria
+
+<!-- What needs to be true for this epic to be considered done? -->
+- [ ]
+- [ ]
+
+## Related Issues / PRs
+
+<!-- Link to any related issues or pull requests -->
+-

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,30 @@
+---
+name: Feature
+about: A new feature or enhancement to existing functionality
+title: "[Feature] "
+labels: feature
+assignees: ''
+---
+
+## Description
+
+<!-- What feature are you proposing? Describe it clearly and concisely. -->
+
+## Motivation
+
+<!-- Why is this feature needed? What user problem or use case does it address? -->
+
+## Proposed Solution
+
+<!-- How do you envision this feature working? Include any design decisions or technical approach. -->
+
+## Acceptance Criteria
+
+<!-- What must be true for this feature to be considered complete? -->
+- [ ]
+- [ ]
+
+## Related Epic / Issues
+
+<!-- Link to the parent epic or related issues -->
+-

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,31 @@
+---
+name: Task
+about: A specific piece of work to be done (refactor, chore, documentation, etc.)
+title: "[Task] "
+labels: task
+assignees: ''
+---
+
+## Description
+
+<!-- What needs to be done? Describe the task clearly. -->
+
+## Background
+
+<!-- Why is this task needed? What is the context? -->
+
+## Steps / Subtasks
+
+<!-- Break down the work into concrete steps if possible -->
+- [ ]
+- [ ]
+
+## Definition of Done
+
+<!-- What needs to be true for this task to be considered complete? -->
+- [ ]
+
+## Related Issues / PRs
+
+<!-- Link to any related issues, epics, or pull requests -->
+-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,23 @@
+## Description
+
+<!-- A clear and concise description of what this PR does and why. -->
+
+## Related Issues
+
+<!-- Link to the issue(s) this PR addresses. Use "Closes #<number>" to auto-close on merge. -->
+Closes #
+
+## Implementation Notes
+
+<!-- Any notable design decisions, trade-offs, or context reviewers should be aware of. -->
+
+## Testing
+
+<!-- How was this tested? What test cases were added or updated? -->
+- [ ] Unit tests added/updated
+- [ ] Ran `cargo test --all`
+- [ ] Ran `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] Ran `cargo fmt --all -- --check`
 
 ## 🔒 Security
 


### PR DESCRIPTION
Adds issue templates for epic, feature, task, and bug types, and updates the PR template to include description, related issues, implementation notes, and testing checklist alongside the existing security checklist.

Closes #15

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized GitHub issue templates for bug reports, feature requests, epics, and tasks to streamline contributions.
  * Enhanced pull request template with structured sections for Description, Related Issues, Implementation Notes, Testing, and Security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->