### PR TITLE
docs: add CI and Security workflow status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # dab-rtl
 
-Most of the code (and contents here) are generated using vibe-coding and Claude from [Anthropic](https://www.anthropic.com/). 
+[![CI](https://github.com/roptaty/dab-rtl/actions/workflows/ci.yml/badge.svg)](https://github.com/roptaty/dab-rtl/actions/workflows/ci.yml)
+[![Security](https://github.com/roptaty/dab-rtl/actions/workflows/security.yml/badge.svg)](https://github.com/roptaty/dab-rtl/actions/workflows/security.yml)
+
+Most of the code (and contents here) are generated using vibe-coding and Claude from [Anthropic](https://www.anthropic.com/).
 
 A pure-Rust DAB/DAB+ software-defined radio receiver for RTL-SDR and HackRF.
 


### PR DESCRIPTION
Adds GitHub Actions status badges for the CI and Security workflows to the top of README.md.

Closes #21

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CI and Security badges to the top of the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->