### PR TITLE
feat: add persistent channel cache (#26)

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -21,6 +21,9 @@ introduce a new crate or upgrade an existing one.
 | `crossterm` | 0.27 | `app` | Cross-platform terminal control | MIT |
 | `cpal` | 0.15 | `audio` | Cross-platform audio output (ALSA) | Apache-2.0 |
 | `symphonia` | 0.5 | `audio` | MP2 / AAC audio decoding | MPL-2.0 |
+| `serde` | 1 | `app` | Serialization framework (derive macros) | MIT / Apache-2.0 |
+| `serde_json` | 1 | `app` | JSON serialization for cache file | MIT / Apache-2.0 |
+| `tempfile` | 3 | `app` (dev) | Temporary directories for cache unit tests | MIT / Apache-2.0 |
 
 ---
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -22,3 +22,8 @@ ratatui     = "0.26"
 crossterm   = "0.27"
 log         = "0.4"
 env_logger  = "0.11"
+serde       = { version = "1", features = ["derive"] }
+serde_json  = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/app/src/cache.rs
+++ b/crates/app/src/cache.rs
@@ -1,0 +1,215 @@
+/// Persistent cache of previously scanned DAB ensembles and services.
+///
+/// The cache is stored as JSON at `$XDG_CONFIG_HOME/dab-rtl/cache.json`
+/// (falling back to `$HOME/.config/dab-rtl/cache.json`).
+///
+/// Keys are upper-cased Band III channel names (e.g. `"11C"`).
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────────── //
+//  Public types                                                                //
+// ─────────────────────────────────────────────────────────────────────────── //
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedService {
+    pub id: u32,
+    pub label: String,
+    pub is_dab_plus: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedEnsemble {
+    pub channel: String,
+    pub ensemble_id: u16,
+    pub ensemble_label: String,
+    pub services: Vec<CachedService>,
+}
+
+impl CachedEnsemble {
+    /// Convert to a `protocol::Ensemble`.  Components are not cached so the
+    /// returned services have empty component lists.
+    pub fn to_ensemble(&self) -> protocol::Ensemble {
+        protocol::Ensemble {
+            id: self.ensemble_id,
+            label: self.ensemble_label.clone(),
+            country_id: 0,
+            services: self
+                .services
+                .iter()
+                .map(|s| protocol::Service {
+                    id: s.id,
+                    label: s.label.clone(),
+                    is_dab_plus: s.is_dab_plus,
+                    components: vec![],
+                })
+                .collect(),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────── //
+//  Cache                                                                       //
+// ─────────────────────────────────────────────────────────────────────────── //
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct CacheFile {
+    #[serde(default)]
+    entries: HashMap<String, CachedEnsemble>,
+}
+
+pub struct Cache {
+    path: PathBuf,
+    data: CacheFile,
+}
+
+impl Cache {
+    /// Load the cache from disk.  Returns an empty cache on any error.
+    pub fn load() -> Self {
+        let path = cache_path();
+        let data = load_file(&path).unwrap_or_default();
+        Cache { path, data }
+    }
+
+    /// Look up a cached ensemble by channel name (case-insensitive).
+    pub fn get(&self, channel: &str) -> Option<&CachedEnsemble> {
+        self.data.entries.get(&channel.to_uppercase())
+    }
+
+    /// Store an ensemble in the cache and flush to disk immediately.
+    pub fn put(&mut self, channel: String, ensemble: CachedEnsemble) {
+        self.data.entries.insert(channel.to_uppercase(), ensemble);
+        self.flush();
+    }
+
+    /// Remove all entries and flush to disk.
+    pub fn clear(&mut self) {
+        self.data.entries.clear();
+        self.flush();
+    }
+
+    /// Path of the cache file on disk.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn flush(&self) {
+        if let Some(parent) = self.path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                log::warn!("cache: could not create directory {}: {e}", parent.display());
+                return;
+            }
+        }
+        match serde_json::to_string_pretty(&self.data) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&self.path, json) {
+                    log::warn!("cache: write failed: {e}");
+                }
+            }
+            Err(e) => log::warn!("cache: serialize failed: {e}"),
+        }
+    }
+}
+
+fn load_file(path: &Path) -> Option<CacheFile> {
+    let text = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn cache_path() -> PathBuf {
+    let config_root = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))
+        .unwrap_or_else(|| PathBuf::from(".config"));
+    config_root.join("dab-rtl").join("cache.json")
+}
+
+// ─────────────────────────────────────────────────────────────────────────── //
+//  Tests                                                                       //
+// ─────────────────────────────────────────────────────────────────────────── //
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn make_cache(dir: &std::path::Path) -> Cache {
+        Cache {
+            path: dir.join("cache.json"),
+            data: CacheFile::default(),
+        }
+    }
+
+    fn sample_ensemble(ch: &str) -> CachedEnsemble {
+        CachedEnsemble {
+            channel: ch.to_string(),
+            ensemble_id: 0x1234,
+            ensemble_label: "Test Ensemble".into(),
+            services: vec![CachedService {
+                id: 0xABCD,
+                label: "Test Radio".into(),
+                is_dab_plus: false,
+            }],
+        }
+    }
+
+    #[test]
+    fn put_and_get() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cache = make_cache(dir.path());
+        cache.put("11C".into(), sample_ensemble("11C"));
+        assert!(cache.get("11C").is_some());
+        assert_eq!(cache.get("11C").unwrap().ensemble_label, "Test Ensemble");
+    }
+
+    #[test]
+    fn get_is_case_insensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cache = make_cache(dir.path());
+        cache.put("11c".into(), sample_ensemble("11C"));
+        assert!(cache.get("11C").is_some());
+        assert!(cache.get("11c").is_some());
+    }
+
+    #[test]
+    fn clear_removes_all_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cache = make_cache(dir.path());
+        cache.put("11C".into(), sample_ensemble("11C"));
+        cache.put("12A".into(), sample_ensemble("12A"));
+        cache.clear();
+        assert!(cache.get("11C").is_none());
+        assert!(cache.get("12A").is_none());
+    }
+
+    #[test]
+    fn round_trip_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cache.json");
+
+        let mut cache = Cache {
+            path: path.clone(),
+            data: CacheFile::default(),
+        };
+        cache.put("9D".into(), sample_ensemble("9D"));
+
+        // Reload from disk.
+        let loaded = Cache {
+            path: path.clone(),
+            data: load_file(&path).unwrap_or_default(),
+        };
+        let ens = loaded.get("9D").expect("round-trip failed");
+        assert_eq!(ens.services[0].label, "Test Radio");
+    }
+
+    #[test]
+    fn to_ensemble_converts_correctly() {
+        let ce = sample_ensemble("11C");
+        let ens = ce.to_ensemble();
+        assert_eq!(ens.id, 0x1234);
+        assert_eq!(ens.label, "Test Ensemble");
+        assert_eq!(ens.services[0].label, "Test Radio");
+    }
+}

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -1,3 +1,4 @@
+mod cache;
 mod countries;
 mod pipeline;
 mod tui;
@@ -64,6 +65,9 @@ enum Command {
         #[arg(short = 'f', long)]
         file: Option<PathBuf>,
     },
+
+    /// Clear the cached channel/service list
+    ClearCache,
 
     /// Play a specific station (non-interactive)
     Play {
@@ -198,6 +202,7 @@ fn main() {
         Command::ListDevices => cmd_list_devices(),
         Command::ListAudio => cmd_list_audio(),
         Command::ListCountries => countries::print_countries(),
+        Command::ClearCache => cmd_clear_cache(),
         Command::Scan {
             channel,
             country,
@@ -365,6 +370,28 @@ fn scan_single(
                 tag,
             );
         }
+
+        // Save to cache when scanning a real channel (not a file source).
+        // cmd_scan never reads pre-existing cache — it always performs a
+        // fresh scan and then overwrites any stale entry.
+        if let (Some(ch), None) = (channel, file) {
+            let cached = cache::CachedEnsemble {
+                channel: ch.to_uppercase(),
+                ensemble_id: ens.id,
+                ensemble_label: ens.label.clone(),
+                services: ens
+                    .services
+                    .iter()
+                    .map(|s| cache::CachedService {
+                        id: s.id,
+                        label: s.label.clone(),
+                        is_dab_plus: s.is_dab_plus,
+                    })
+                    .collect(),
+            };
+            let mut c = cache::Cache::load();
+            c.put(ch.to_uppercase(), cached);
+        }
     }
 }
 
@@ -380,6 +407,14 @@ fn cmd_tune(
     let label = source_label(file.as_ref(), channel.as_deref());
     println!("Tuning to {label}…");
 
+    // Pre-populate the TUI from cache so services appear immediately.
+    // This is read-only here — cmd_scan is the only writer.
+    let channel_key = channel.as_deref().map(|c| c.to_uppercase());
+    let initial_ensemble = channel_key.as_deref().and_then(|ch| {
+        let c = cache::Cache::load();
+        c.get(ch).map(|e| e.to_ensemble())
+    });
+
     let stream = open_iq_source(file.as_ref(), channel.as_deref(), device_idx, ppm, gain);
 
     let handle = match pipeline::start_with_stream(stream, audio_device) {
@@ -390,7 +425,7 @@ fn cmd_tune(
         }
     };
 
-    if let Err(e) = tui::run(handle) {
+    if let Err(e) = tui::run(handle, channel_key, initial_ensemble) {
         eprintln!("TUI error: {e}");
     }
 }
@@ -410,6 +445,19 @@ fn cmd_play(
     let label = source_label(file.as_ref(), channel.as_deref());
     println!("Searching for '{station}' on {label}…  Press Ctrl-C to stop.");
 
+    // Fast path: look the station up in the cache so we can send the Play
+    // command before the FIC decoder has decoded the first ensemble frame.
+    let channel_key = channel.as_deref().map(|c| c.to_uppercase());
+    let cached_sid = channel_key.as_deref().and_then(|ch| {
+        let c = cache::Cache::load();
+        c.get(ch).and_then(|ens| {
+            ens.services
+                .iter()
+                .find(|s| s.label.to_lowercase().contains(&station.to_lowercase()))
+                .map(|s| s.id)
+        })
+    });
+
     let stream = open_iq_source(file.as_ref(), channel.as_deref(), device_idx, ppm, gain);
 
     let handle = match pipeline::start_with_stream(stream, audio_device) {
@@ -420,7 +468,14 @@ fn cmd_play(
         }
     };
 
-    let mut started = false;
+    // If we found the station in cache, request playback immediately.
+    let mut started = if let Some(sid) = cached_sid {
+        println!("Found in cache — requesting playback immediately");
+        let _ = handle.cmd_tx.try_send(PipelineCmd::Play(sid));
+        true
+    } else {
+        false
+    };
 
     for update in handle.update_rx.iter() {
         match update {
@@ -444,6 +499,14 @@ fn cmd_play(
             }
         }
     }
+}
+
+/// Clear the on-disk service cache.
+fn cmd_clear_cache() {
+    let mut c = cache::Cache::load();
+    let path = c.path().to_path_buf();
+    c.clear();
+    println!("Cache cleared: {}", path.display());
 }
 
 // ─────────────────────────────────────────────────────────────────────────── //

--- a/crates/app/src/tui.rs
+++ b/crates/app/src/tui.rs
@@ -39,17 +39,32 @@ struct AppState {
     list_state: ListState,
     playing_label: Option<String>,
     status: String,
+    /// `true` while the service list comes from the cache rather than live FIC.
+    cached: bool,
+    /// The channel name — used as the cache key when the user clears the cache.
+    channel: Option<String>,
 }
 
 impl AppState {
-    fn new() -> Self {
+    fn new(channel: Option<String>, initial_ensemble: Option<Ensemble>) -> Self {
+        let cached = initial_ensemble.is_some();
+        let ensemble = initial_ensemble.unwrap_or_default();
         let mut list_state = ListState::default();
-        list_state.select(Some(0));
+        if !ensemble.services.is_empty() {
+            list_state.select(Some(0));
+        }
+        let status = if cached {
+            "Loaded from cache — waiting for live signal…".into()
+        } else {
+            "Waiting for signal…".into()
+        };
         AppState {
-            ensemble: Ensemble::default(),
+            ensemble,
             list_state,
             playing_label: None,
-            status: "Waiting for signal…".into(),
+            status,
+            cached,
+            channel,
         }
     }
 
@@ -81,7 +96,15 @@ impl AppState {
 // ─────────────────────────────────────────────────────────────────────────── //
 
 /// Run the TUI until the user presses `q` or `Esc`.
-pub fn run(handle: PipelineHandle) -> io::Result<()> {
+///
+/// `channel` is the Band III channel name used as the cache key.
+/// `initial_ensemble` pre-populates the service list from the cache so it is
+/// visible immediately, before the first live FIC frame is decoded.
+pub fn run(
+    handle: PipelineHandle,
+    channel: Option<String>,
+    initial_ensemble: Option<Ensemble>,
+) -> io::Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -89,7 +112,7 @@ pub fn run(handle: PipelineHandle) -> io::Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run_loop(&mut terminal, handle);
+    let result = run_loop(&mut terminal, handle, channel, initial_ensemble);
 
     // Always restore terminal.
     disable_raw_mode()?;
@@ -102,8 +125,10 @@ pub fn run(handle: PipelineHandle) -> io::Result<()> {
 fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     handle: PipelineHandle,
+    channel: Option<String>,
+    initial_ensemble: Option<Ensemble>,
 ) -> io::Result<()> {
-    let mut state = AppState::new();
+    let mut state = AppState::new(channel, initial_ensemble);
     let tick = Duration::from_millis(200);
     let mut last_tick = Instant::now();
 
@@ -115,6 +140,7 @@ fn run_loop(
                     // Preserve selection if possible.
                     let old_sid = state.selected_sid();
                     state.ensemble = ens;
+                    state.cached = false; // live data supersedes cache
                     if state.ensemble.services.is_empty() {
                         state.list_state.select(None);
                     } else {
@@ -159,6 +185,14 @@ fn run_loop(
                         state.playing_label = None;
                         state.status = "Stopped".into();
                     }
+                    KeyCode::Char('X') => {
+                        let mut c = crate::cache::Cache::load();
+                        let path = c.path().to_path_buf();
+                        c.clear();
+                        state.cached = false;
+                        state.status =
+                            format!("Cache cleared ({})", path.display());
+                    }
                     _ => {}
                 }
             }
@@ -197,6 +231,8 @@ fn render(f: &mut Frame, state: &mut AppState) {
 fn render_service_list(f: &mut Frame, state: &mut AppState, area: ratatui::layout::Rect) {
     let ens_title = if state.ensemble.label.is_empty() {
         " Services ".to_string()
+    } else if state.cached {
+        format!(" {} (cached) ", state.ensemble.label)
     } else {
         format!(" {} ", state.ensemble.label)
     };
@@ -271,7 +307,7 @@ fn render_now_playing(f: &mut Frame, state: &AppState, area: ratatui::layout::Re
 
 fn render_status_bar(f: &mut Frame, state: &AppState, area: ratatui::layout::Rect) {
     let help = Span::styled(
-        " [↑↓/jk] Navigate  [Enter] Play  [s] Stop  [q] Quit ",
+        " [↑↓/jk] Navigate  [Enter] Play  [s] Stop  [X] Clear cache  [q] Quit ",
         Style::default().fg(Color::DarkGray),
     );
     let status = Span::styled(


### PR DESCRIPTION
Cache discovered DAB ensembles to `~/.config/dab-rtl/cache.json` so that tune and play show results immediately on subsequent runs.

- `cmd_scan` always performs a fresh scan, then writes results to cache
- `cmd_tune` pre-populates the TUI from cache (shows "(cached)" label)
- `cmd_play` fast-path lookup from cache before FIC decode
- TUI `X` key and `clear-cache` CLI subcommand

Closes #26

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent service caching to disk for faster subsequent access
  * Cache automatically populates during scanning and restores on startup
  * New "clear cache" CLI command and keyboard shortcut (X) to manually clear cached data
  * TUI displays "(cached)" indicator when showing cached service information

* **Chores**
  * Added serialization and temporary file handling dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->